### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix Log Injection / Log Forging in AutoCollapseManager and StickyHeaderComponent

### DIFF
--- a/src/main/kotlin/com/github/erjotek/stickyprojectfolder/ui/AutoCollapseManager.kt
+++ b/src/main/kotlin/com/github/erjotek/stickyprojectfolder/ui/AutoCollapseManager.kt
@@ -290,7 +290,7 @@ class AutoCollapseManager(
         val treePath = findExpandedTreePathForDirectory(absolutePath, rootPath)
 
         if (treePath != null && tree.isExpanded(treePath)) {
-            LOG.info("Collapsing: $relativePath")
+            LOG.info("Collapsing: ${relativePath.replace('\n', '_').replace('\r', '_')}")
             tree.collapsePath(treePath)
             return true
         }

--- a/src/main/kotlin/com/github/erjotek/stickyprojectfolder/ui/StickyHeaderComponent.kt
+++ b/src/main/kotlin/com/github/erjotek/stickyprojectfolder/ui/StickyHeaderComponent.kt
@@ -253,7 +253,7 @@ class StickyHeaderComponent(
         LOG.info("Target directory found")
 
         val transferable = e.transferable
-        LOG.info("Available flavors: ${transferable.transferDataFlavors.map { it.mimeType }}")
+        LOG.info("Available flavors: ${transferable.transferDataFlavors.map { it.mimeType.replace('\n', '_').replace('\r', '_') }}")
 
         val psiElements = ReadAction.compute<Array<PsiElement>, Nothing> {
             extractPsiElementsFromTransferable(transferable)
@@ -351,7 +351,7 @@ class StickyHeaderComponent(
                 if (e is java.awt.datatransfer.UnsupportedFlavorException || e is java.io.IOException) {
                     continue
                 } else {
-                    LOG.error("Failed to get transfer data for flavor ${flavor.mimeType}", e)
+                    LOG.error("Failed to get transfer data for flavor ${flavor.mimeType.replace('\n', '_').replace('\r', '_')}", e)
                     continue
                 }
             }


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Log Injection / Log Forging (CWE-117). The `AutoCollapseManager` logged user-configurable path settings directly into the application log, and `StickyHeaderComponent` logged `mimeType` names from drag-and-drop `Transferable` items directly into the log. Both pieces of data could be crafted by an attacker or a malicious process to include newline characters (`\n` and `\r`).
🎯 **Impact:** If an attacker crafts a malicious `Transferable` object or a user adds a specific directory path with newline characters to settings, it could inject fake log entries, forge logs, or corrupt the structured log formatting.
🔧 **Fix:** Sanitized all occurrences of `relativePath` and `flavor.mimeType` within logging calls using `.replace('\n', '_').replace('\r', '_')` to ensure no newline sequences can be injected into standard log output.
✅ **Verification:** Verified by checking that compilation passes, there are no test regressions via `./gradlew test --no-daemon`, and that the `LOG.info` and `LOG.error` sites use the modified string values.

---
*PR created automatically by Jules for task [9595902780924423119](https://jules.google.com/task/9595902780924423119) started by @erjotek*