### PR TITLE
🛡️ Sentinel: [HIGH] Fix HTML Injection in PinnedFolders Settings

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Several logs (`StickyHeaderComponent.kt` tracking mimeTypes, `PinnedFoldersSettings.kt` and `PathValidator.kt` tracking file paths) logged external or user inputs directly via String template injection without sanitizing CRLF `\n` and `\r` characters.
 **Learning:** Even internal settings, file paths, and MIME types coming from system clipboards can be tampered with by an attacker to forge log entries or obscure traces.
 **Prevention:** Always use the `PathValidator.sanitizeForLog()` utility function when passing external, user-supplied, or potentially tampered strings to `LOG.warn`, `LOG.error`, or `LOG.info`.
+
+## 2024-06-03 - [Fix HTML Injection in Pinned Folders Settings]
+**Vulnerability:** A standard `DefaultTableCellRenderer` in Swing interprets strings starting with `<html>` as HTML, allowing for HTML injection / UI-based XSS when displaying user-controlled text like file descriptions.
+**Learning:** We had already protected the list of auto-collapse paths with `putClientProperty("html.disable", true)`, but missed the Pinned Folders table because it uses a different renderer mechanism (`DefaultTableCellRenderer` vs `ListCellRenderer`). Any Swing component rendering user input needs this property.
+**Prevention:** Always apply `.putClientProperty("html.disable", true)` to any `JLabel` or `JComponent` acting as a cell renderer in Swing applications when rendering potentially untrusted user data or file paths.

--- a/src/main/kotlin/com/github/erjotek/stickyprojectfolder/settings/StickyProjectConfigurable.kt
+++ b/src/main/kotlin/com/github/erjotek/stickyprojectfolder/settings/StickyProjectConfigurable.kt
@@ -187,6 +187,7 @@ class StickyProjectConfigurable(
                 table: javax.swing.JTable, value: Any?, isSelected: Boolean, hasFocus: Boolean, row: Int, column: Int
             ): Component {
                 val comp = super.getTableCellRendererComponent(table, value, isSelected, hasFocus, row, column)
+                (comp as? JComponent)?.putClientProperty("html.disable", true)
                 if (!isSelected) {
                     val item = pinnedTableModel?.items?.getOrNull(row)
                     if (item != null) {


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: HTML Injection (UI-based XSS) in the Pinned Folders Settings table. The `DefaultTableCellRenderer` uses `JLabel` internally, which interprets strings starting with `<html>` as HTML. This allows arbitrary HTML/CSS to be rendered if a malicious or crafted string is added as a pinned folder description.
🎯 Impact: An attacker (or a user tricked into adding a specific folder name/description) could execute malicious HTML, potentially altering the UI, phish for credentials via UI spoofing, or execute further attacks depending on the Swing HTML renderer capabilities.
🔧 Fix: Added `(comp as? JComponent)?.putClientProperty("html.disable", true)` to the `DefaultTableCellRenderer` in `StickyProjectConfigurable` for the Pinned Folders table, matching the existing protection in the `PathListCellRenderer`.
✅ Verification: Tested locally via `./gradlew test --no-daemon`. Verified that descriptions starting with `<html>` are now rendered as literal text instead of HTML elements.

---
*PR created automatically by Jules for task [12151953040861241048](https://jules.google.com/task/12151953040861241048) started by @erjotek*