### PR TITLE
🛡️ Sentinel: [HIGH] Fix HTML Injection in Swing TableCellRenderer

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** Several logs (`StickyHeaderComponent.kt` tracking mimeTypes, `PinnedFoldersSettings.kt` and `PathValidator.kt` tracking file paths) logged external or user inputs directly via String template injection without sanitizing CRLF `\n` and `\r` characters.
 **Learning:** Even internal settings, file paths, and MIME types coming from system clipboards can be tampered with by an attacker to forge log entries or obscure traces.
 **Prevention:** Always use the `PathValidator.sanitizeForLog()` utility function when passing external, user-supplied, or potentially tampered strings to `LOG.warn`, `LOG.error`, or `LOG.info`.
+## 2024-05-24 - [Disable HTML rendering in Swing TableCellRenderer]
+**Vulnerability:** Swing components like `JLabel` (used by `DefaultTableCellRenderer`) interpret strings starting with `<html>` as HTML, which can lead to HTML injection/XSS if a user provides a malicious path or description.
+**Learning:** Swing components render HTML by default, which is a security risk when displaying unvalidated user input.
+**Prevention:** Always explicitly disable HTML rendering by calling `.putClientProperty("html.disable", true)` on Swing components displaying user-provided strings.

--- a/src/main/kotlin/com/github/erjotek/stickyprojectfolder/settings/StickyProjectConfigurable.kt
+++ b/src/main/kotlin/com/github/erjotek/stickyprojectfolder/settings/StickyProjectConfigurable.kt
@@ -187,6 +187,7 @@ class StickyProjectConfigurable(
                 table: javax.swing.JTable, value: Any?, isSelected: Boolean, hasFocus: Boolean, row: Int, column: Int
             ): Component {
                 val comp = super.getTableCellRendererComponent(table, value, isSelected, hasFocus, row, column)
+                (comp as? javax.swing.JComponent)?.putClientProperty("html.disable", true)
                 if (!isSelected) {
                     val item = pinnedTableModel?.items?.getOrNull(row)
                     if (item != null) {


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix HTML Injection in Swing TableCellRenderer

**🚨 Severity:** HIGH
**💡 Vulnerability:** Swing components like `JLabel` (used implicitly by `DefaultTableCellRenderer`) interpret strings starting with `<html>` as HTML. When displaying user-controlled or unvalidated input (such as file paths, directory names, or custom descriptions) in a table without disabling HTML rendering, this creates a vector for HTML injection or XSS-like vulnerabilities within the IDE UI.
**🎯 Impact:** A maliciously crafted project name or directory name containing HTML tags could cause UI spoofing, arbitrary HTML rendering, or hang the Swing UI thread due to complex rendering.
**🔧 Fix:** Explicitly disabled HTML rendering on the table cell renderer by calling `.putClientProperty("html.disable", true)` on the `JComponent` inside `getTableCellRendererComponent`.
**✅ Verification:**
1. Ran the plugin test suite successfully.
2. Verified that literal HTML strings in the table will now be safely rendered as plain text.

---
*PR created automatically by Jules for task [17258415711243385631](https://jules.google.com/task/17258415711243385631) started by @erjotek*