### PR TITLE
🛡️ Sentinel: [HIGH] Fix HTML Injection in Pinned Folders Table

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Several logs (`StickyHeaderComponent.kt` tracking mimeTypes, `PinnedFoldersSettings.kt` and `PathValidator.kt` tracking file paths) logged external or user inputs directly via String template injection without sanitizing CRLF `\n` and `\r` characters.
 **Learning:** Even internal settings, file paths, and MIME types coming from system clipboards can be tampered with by an attacker to forge log entries or obscure traces.
 **Prevention:** Always use the `PathValidator.sanitizeForLog()` utility function when passing external, user-supplied, or potentially tampered strings to `LOG.warn`, `LOG.error`, or `LOG.info`.
+
+## 2024-05-31 - Fix HTML Injection / XSS in Pinned Folders Table
+**Vulnerability:** The custom `DefaultTableCellRenderer` in `StickyProjectConfigurable.kt` rendered user-editable strings (pinned folder descriptions) without disabling HTML rendering, creating an HTML Injection / XSS risk within the IDE's Swing UI.
+**Learning:** Swing components like `JLabel`, `DefaultTableCellRenderer`, and `DefaultListCellRenderer` automatically parse strings starting with `<html>` as HTML. This can be exploited if they render untrusted or user-modifiable data.
+**Prevention:** Always set `.putClientProperty("html.disable", true)` during the initialization of any custom cell renderer or label that displays potentially attacker-controlled or user-editable content.

--- a/src/main/kotlin/com/github/erjotek/stickyprojectfolder/settings/StickyProjectConfigurable.kt
+++ b/src/main/kotlin/com/github/erjotek/stickyprojectfolder/settings/StickyProjectConfigurable.kt
@@ -183,6 +183,10 @@ class StickyProjectConfigurable(
 
         // Custom renderer: gray out non-existent paths (both path and description columns)
         pinnedTable!!.setDefaultRenderer(Any::class.java, object : javax.swing.table.DefaultTableCellRenderer() {
+            init {
+                putClientProperty("html.disable", true)
+            }
+
             override fun getTableCellRendererComponent(
                 table: javax.swing.JTable, value: Any?, isSelected: Boolean, hasFocus: Boolean, row: Int, column: Int
             ): Component {


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The custom `DefaultTableCellRenderer` in `StickyProjectConfigurable.kt` was rendering user-editable strings (pinned folder descriptions) without disabling HTML rendering. Swing automatically interprets strings starting with `<html>` as HTML, creating an HTML Injection / XSS risk within the IDE UI.
🎯 Impact: An attacker or a malicious configuration could inject HTML/CSS into the settings panel, potentially misleading the user or disrupting the IDE's UI layout.
🔧 Fix: Added `.putClientProperty("html.disable", true)` to the `DefaultTableCellRenderer` initialization block, forcing it to render the user-provided text as plain text.
✅ Verification: Verify that the settings compile successfully (`./gradlew compileKotlin -x test`) and that entering `<html><b>test</b></html>` in the pinned folder description now renders the literal string rather than bold text.

---
*PR created automatically by Jules for task [17052470554085866898](https://jules.google.com/task/17052470554085866898) started by @erjotek*