### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix HTML Injection in Settings Table

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Several logs (`StickyHeaderComponent.kt` tracking mimeTypes, `PinnedFoldersSettings.kt` and `PathValidator.kt` tracking file paths) logged external or user inputs directly via String template injection without sanitizing CRLF `\n` and `\r` characters.
 **Learning:** Even internal settings, file paths, and MIME types coming from system clipboards can be tampered with by an attacker to forge log entries or obscure traces.
 **Prevention:** Always use the `PathValidator.sanitizeForLog()` utility function when passing external, user-supplied, or potentially tampered strings to `LOG.warn`, `LOG.error`, or `LOG.info`.
+
+## 2024-05-31 - Fix HTML Injection Vulnerability
+**Vulnerability:** Swing components like `DefaultTableCellRenderer` (which extends `JLabel`) interpret strings starting with `<html>` as HTML by default. In `StickyProjectConfigurable.kt`, the renderer for the Pinned Folders table displayed user-editable descriptions and file paths without disabling this behavior.
+**Learning:** Even internal settings like file paths or user-provided descriptions can be abused for UI redressing, spoofing, or hanging the UI if an attacker manages to inject `<html>` tags into these fields.
+**Prevention:** Always explicitly disable HTML rendering on Swing components displaying user-provided or unvalidated strings by calling `putClientProperty("html.disable", true)`.

--- a/src/main/kotlin/com/github/erjotek/stickyprojectfolder/settings/StickyProjectConfigurable.kt
+++ b/src/main/kotlin/com/github/erjotek/stickyprojectfolder/settings/StickyProjectConfigurable.kt
@@ -183,6 +183,10 @@ class StickyProjectConfigurable(
 
         // Custom renderer: gray out non-existent paths (both path and description columns)
         pinnedTable!!.setDefaultRenderer(Any::class.java, object : javax.swing.table.DefaultTableCellRenderer() {
+            init {
+                putClientProperty("html.disable", true)
+            }
+
             override fun getTableCellRendererComponent(
                 table: javax.swing.JTable, value: Any?, isSelected: Boolean, hasFocus: Boolean, row: Int, column: Int
             ): Component {


### PR DESCRIPTION
🚨 **Severity**: MEDIUM
💡 **Vulnerability**: Swing components like `DefaultTableCellRenderer` (which extend `JLabel`) render strings starting with `<html>` as HTML by default. In `StickyProjectConfigurable.kt`, user-provided file descriptions and paths were being displayed without explicitly disabling this behavior, creating an HTML Injection vulnerability.
🎯 **Impact**: If an attacker crafts a project folder starting with `<html>` or a user provides a description starting with `<html>`, Swing attempts to parse the content as HTML. This can lead to UI redressing (spoofing the interface layout) or hanging the application via catastrophic backtracking within the HTML parser.
🔧 **Fix**: Added an `init` block to the custom `DefaultTableCellRenderer` applied to the Pinned Folders table, explicitly invoking `putClientProperty("html.disable", true)`. This forces the renderer to treat the contents strictly as plain text.
✅ **Verification**: The project compiled and passed existing unit tests without errors. The fix has been reviewed securely.

---
*PR created automatically by Jules for task [5216759223981524896](https://jules.google.com/task/5216759223981524896) started by @erjotek*