### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in settings UI

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Several logs (`StickyHeaderComponent.kt` tracking mimeTypes, `PinnedFoldersSettings.kt` and `PathValidator.kt` tracking file paths) logged external or user inputs directly via String template injection without sanitizing CRLF `\n` and `\r` characters.
 **Learning:** Even internal settings, file paths, and MIME types coming from system clipboards can be tampered with by an attacker to forge log entries or obscure traces.
 **Prevention:** Always use the `PathValidator.sanitizeForLog()` utility function when passing external, user-supplied, or potentially tampered strings to `LOG.warn`, `LOG.error`, or `LOG.info`.
+
+## $(date +%Y-%m-%d) - Prevent XSS in DefaultTableCellRenderer
+**Vulnerability:** HTML Injection / XSS in Swing `DefaultTableCellRenderer` used in Settings UI for paths.
+**Learning:** Default implementations of Swing renderers like `DefaultTableCellRenderer` inherit from `JLabel` and parse strings starting with `<html>` as HTML, allowing for UI manipulation or malicious execution if untrusted input is displayed.
+**Prevention:** Explicitly set the client property `(comp as? javax.swing.JComponent)?.putClientProperty("html.disable", true)` on the returned component within `getTableCellRendererComponent` when displaying user input or file paths.

--- a/src/main/kotlin/com/github/erjotek/stickyprojectfolder/settings/StickyProjectConfigurable.kt
+++ b/src/main/kotlin/com/github/erjotek/stickyprojectfolder/settings/StickyProjectConfigurable.kt
@@ -187,6 +187,7 @@ class StickyProjectConfigurable(
                 table: javax.swing.JTable, value: Any?, isSelected: Boolean, hasFocus: Boolean, row: Int, column: Int
             ): Component {
                 val comp = super.getTableCellRendererComponent(table, value, isSelected, hasFocus, row, column)
+                (comp as? javax.swing.JComponent)?.putClientProperty("html.disable", true)
                 if (!isSelected) {
                     val item = pinnedTableModel?.items?.getOrNull(row)
                     if (item != null) {


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `DefaultTableCellRenderer` instance used in `StickyProjectConfigurable` inherits from `JLabel`, which interprets strings starting with `<html>` as HTML. This creates an HTML injection / XSS vulnerability where malicious or malformed folder paths or descriptions could manipulate the UI or execute scripts within the IDE context.
🎯 Impact: Attackers could inject arbitrary HTML content via external configuration modifications or maliciously crafted folder structures, leading to UI redressing or execution of malicious components within the IDE.
🔧 Fix: Explicitly disabled HTML rendering by adding `(comp as? javax.swing.JComponent)?.putClientProperty("html.disable", true)` within the `getTableCellRendererComponent` method before returning the component.
✅ Verification: Code visually verified; tests could not be executed locally due to a Gradle server availability issue (502 error downloading Gradle 9.4.0 distribution), but the change is a one-line logical addition to properties that doesn't modify operational control flow.

---
*PR created automatically by Jules for task [8098938655747444857](https://jules.google.com/task/8098938655747444857) started by @erjotek*