### PR TITLE
🛡️ Sentinel: [security improvement] Prevent HTML injection in Pinned Folders settings table

### DIFF
--- a/src/main/kotlin/com/github/erjotek/stickyprojectfolder/settings/StickyProjectConfigurable.kt
+++ b/src/main/kotlin/com/github/erjotek/stickyprojectfolder/settings/StickyProjectConfigurable.kt
@@ -187,6 +187,7 @@ class StickyProjectConfigurable(
                 table: javax.swing.JTable, value: Any?, isSelected: Boolean, hasFocus: Boolean, row: Int, column: Int
             ): Component {
                 val comp = super.getTableCellRendererComponent(table, value, isSelected, hasFocus, row, column)
+                (comp as? javax.swing.JComponent)?.putClientProperty("html.disable", true)
                 if (!isSelected) {
                     val item = pinnedTableModel?.items?.getOrNull(row)
                     if (item != null) {


### PR DESCRIPTION
🚨 **Severity:** LOW/MEDIUM
💡 **Vulnerability:** Unsanitized Swing component rendering allowed HTML Injection/XSS if a pinned folder path or description contained `<html>` tags.
🎯 **Impact:** An attacker or malicious project config could spoof the UI or cause rendering issues by injecting custom HTML into the Pinned Folders settings table.
🔧 **Fix:** Added `putClientProperty("html.disable", true)` to the `DefaultTableCellRenderer` in `StickyProjectConfigurable.kt`.
✅ **Verification:** Re-ran `./gradlew test --no-daemon` and confirmed tests pass. Evaluated the Swing documentation for standard mitigation against HTML injection in basic table cells.

---
*PR created automatically by Jules for task [3379525927645766777](https://jules.google.com/task/3379525927645766777) started by @erjotek*