### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix potential HTML injection in Pinned Folders table

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Several logs (`StickyHeaderComponent.kt` tracking mimeTypes, `PinnedFoldersSettings.kt` and `PathValidator.kt` tracking file paths) logged external or user inputs directly via String template injection without sanitizing CRLF `\n` and `\r` characters.
 **Learning:** Even internal settings, file paths, and MIME types coming from system clipboards can be tampered with by an attacker to forge log entries or obscure traces.
 **Prevention:** Always use the `PathValidator.sanitizeForLog()` utility function when passing external, user-supplied, or potentially tampered strings to `LOG.warn`, `LOG.error`, or `LOG.info`.
+
+## 2025-02-23 - Prevent HTML Injection in Swing Table Renderers
+**Vulnerability:** The `DefaultTableCellRenderer` for `pinnedTable` rendered raw strings (folder paths and descriptions) without disabling HTML interpretation, exposing a potential HTML injection/XSS vulnerability if a user enters a description like `<html>...`.
+**Learning:** Swing components (like `JLabel` and table renderers based on it) interpret strings starting with `<html>` by default. Even local settings inputs can be used for UI redressing or HTML injection.
+**Prevention:** Explicitly disable HTML rendering by calling `.putClientProperty("html.disable", true)` on the `JComponent` returned by a custom cell renderer when displaying unvalidated or user-provided strings.

--- a/src/main/kotlin/com/github/erjotek/stickyprojectfolder/settings/StickyProjectConfigurable.kt
+++ b/src/main/kotlin/com/github/erjotek/stickyprojectfolder/settings/StickyProjectConfigurable.kt
@@ -187,6 +187,7 @@ class StickyProjectConfigurable(
                 table: javax.swing.JTable, value: Any?, isSelected: Boolean, hasFocus: Boolean, row: Int, column: Int
             ): Component {
                 val comp = super.getTableCellRendererComponent(table, value, isSelected, hasFocus, row, column)
+                (comp as? javax.swing.JComponent)?.putClientProperty("html.disable", true)
                 if (!isSelected) {
                     val item = pinnedTableModel?.items?.getOrNull(row)
                     if (item != null) {


### PR DESCRIPTION
## 🚨 Severity: MEDIUM

## 💡 Vulnerability
The `DefaultTableCellRenderer` used for the `pinnedTable` (which displays pinned folder paths and descriptions) defaults to allowing HTML rendering. If a user inputs a description starting with `<html>`, it will be interpreted as HTML. While this might seem benign since settings are local, this can be exploited for UI redressing or HTML injection, making it a classic Swing vulnerability.

## 🎯 Impact
A maliciously crafted path or folder description could execute unexpected HTML layout behavior or potentially lead to limited UI manipulation within the settings dialog. It breaks the defense-in-depth model for secure input rendering.

## 🔧 Fix
Explicitly disabled HTML rendering for the customized `JTable` cells by calling `putClientProperty("html.disable", true)` on the returned `JComponent` from `getTableCellRendererComponent`.

## ✅ Verification
1. Ensure the code compiles and tests pass via `./gradlew test --no-daemon`.
2. Inspect `StickyProjectConfigurable.kt` around line 187.

---
*PR created automatically by Jules for task [17172750949130591935](https://jules.google.com/task/17172750949130591935) started by @erjotek*