### PR TITLE
🛡️ Sentinel: [HIGH] Fix Swing HTML Injection in Configurable

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Several logs (`StickyHeaderComponent.kt` tracking mimeTypes, `PinnedFoldersSettings.kt` and `PathValidator.kt` tracking file paths) logged external or user inputs directly via String template injection without sanitizing CRLF `\n` and `\r` characters.
 **Learning:** Even internal settings, file paths, and MIME types coming from system clipboards can be tampered with by an attacker to forge log entries or obscure traces.
 **Prevention:** Always use the `PathValidator.sanitizeForLog()` utility function when passing external, user-supplied, or potentially tampered strings to `LOG.warn`, `LOG.error`, or `LOG.info`.
+
+## 2024-05-31 - Fix Swing HTML Injection Vulnerability
+**Vulnerability:** Swing components like `JLabel` and subclasses like `DefaultTableCellRenderer` parse strings starting with `<html>` as HTML, allowing arbitrary HTML execution (Swing XSS / HTML Injection).
+**Learning:** Even when displaying non-web data in internal IDE settings like Table Renderers (e.g. for user-provided paths/descriptions in `StickyProjectConfigurable`), untrusted inputs can trigger HTML injection if not explicitly disabled.
+**Prevention:** Always disable HTML rendering on display components handling user-controlled strings by calling `putClientProperty("html.disable", true)`.

--- a/src/main/kotlin/com/github/erjotek/stickyprojectfolder/settings/StickyProjectConfigurable.kt
+++ b/src/main/kotlin/com/github/erjotek/stickyprojectfolder/settings/StickyProjectConfigurable.kt
@@ -187,6 +187,7 @@ class StickyProjectConfigurable(
                 table: javax.swing.JTable, value: Any?, isSelected: Boolean, hasFocus: Boolean, row: Int, column: Int
             ): Component {
                 val comp = super.getTableCellRendererComponent(table, value, isSelected, hasFocus, row, column)
+                (comp as? javax.swing.JComponent)?.putClientProperty("html.disable", true)
                 if (!isSelected) {
                     val item = pinnedTableModel?.items?.getOrNull(row)
                     if (item != null) {


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Swing HTML Injection / XSS. Swing components (like `JLabel` used by `DefaultTableCellRenderer`) evaluate strings starting with `<html>` as HTML. This allows unvalidated user input (like file descriptions or paths in the Pinned Folders settings table) to execute arbitrary HTML or load remote resources.
🎯 **Impact:** An attacker or malicious project configuration could inject malformed HTML to perform UI spoofing, denial of service via UI breakage, or track users by loading remote images (e.g., `<img src="...">`).
🔧 **Fix:** Explicitly disabled HTML rendering for the table cell renderer in `StickyProjectConfigurable.kt` by calling `putClientProperty("html.disable", true)` on the returned `JComponent`. Added a journal entry to document this Swing specific vulnerability pattern.
✅ **Verification:** Verified that tests pass via `./gradlew test --no-daemon`.

---
*PR created automatically by Jules for task [14650179242722163531](https://jules.google.com/task/14650179242722163531) started by @erjotek*