### PR TITLE
🛡️ Sentinel: [HIGH] Fix HTML injection in Pinned Folders settings table

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** Several logs (`StickyHeaderComponent.kt` tracking mimeTypes, `PinnedFoldersSettings.kt` and `PathValidator.kt` tracking file paths) logged external or user inputs directly via String template injection without sanitizing CRLF `\n` and `\r` characters.
 **Learning:** Even internal settings, file paths, and MIME types coming from system clipboards can be tampered with by an attacker to forge log entries or obscure traces.
 **Prevention:** Always use the `PathValidator.sanitizeForLog()` utility function when passing external, user-supplied, or potentially tampered strings to `LOG.warn`, `LOG.error`, or `LOG.info`.
+## 2024-05-24 - Fix HTML injection in Pinned Folders settings table
+**Vulnerability:** A custom `DefaultTableCellRenderer` in `StickyProjectConfigurable` was rendering user-provided paths and descriptions without disabling HTML rendering.
+**Learning:** Swing components like `JLabel` interpret strings starting with `<html>` as HTML by default. When displaying user-provided strings in tables or lists, this can lead to HTML injection/XSS.
+**Prevention:** Explicitly disable HTML rendering on the component returned by the renderer using `(comp as? javax.swing.JComponent)?.putClientProperty("html.disable", true)`.

--- a/src/main/kotlin/com/github/erjotek/stickyprojectfolder/settings/StickyProjectConfigurable.kt
+++ b/src/main/kotlin/com/github/erjotek/stickyprojectfolder/settings/StickyProjectConfigurable.kt
@@ -187,6 +187,10 @@ class StickyProjectConfigurable(
                 table: javax.swing.JTable, value: Any?, isSelected: Boolean, hasFocus: Boolean, row: Int, column: Int
             ): Component {
                 val comp = super.getTableCellRendererComponent(table, value, isSelected, hasFocus, row, column)
+
+                // Prevent HTML injection in paths/descriptions
+                (comp as? javax.swing.JComponent)?.putClientProperty("html.disable", true)
+
                 if (!isSelected) {
                     val item = pinnedTableModel?.items?.getOrNull(row)
                     if (item != null) {


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The `DefaultTableCellRenderer` in `StickyProjectConfigurable` was rendering user-provided paths and descriptions without disabling HTML rendering. Swing components like `JLabel` interpret strings starting with `<html>` as HTML by default. When displaying unvalidated strings in tables or lists, this can lead to HTML injection/XSS vulnerabilities within the settings UI.
🎯 **Impact:** If a user inputs a malicious path or description starting with `<html>`, the `JLabel` will render it as HTML. This can be exploited to perform HTML injection or execute arbitrary scripts (XSS) within the context of the IntelliJ Platform UI.
🔧 **Fix:** Explicitly disable HTML rendering on the component returned by the custom `DefaultTableCellRenderer` using `(comp as? javax.swing.JComponent)?.putClientProperty("html.disable", true)`. This forces the component to render the text securely as plain text.
✅ **Verification:** Run `./gradlew test --no-daemon` to ensure tests still pass. No new regressions observed.

---
*PR created automatically by Jules for task [8013544723269874775](https://jules.google.com/task/8013544723269874775) started by @erjotek*