### PR TITLE
🛡️ Sentinel: [HIGH] Fix HTML Injection in Swing Table Renderer

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Several logs (`StickyHeaderComponent.kt` tracking mimeTypes, `PinnedFoldersSettings.kt` and `PathValidator.kt` tracking file paths) logged external or user inputs directly via String template injection without sanitizing CRLF `\n` and `\r` characters.
 **Learning:** Even internal settings, file paths, and MIME types coming from system clipboards can be tampered with by an attacker to forge log entries or obscure traces.
 **Prevention:** Always use the `PathValidator.sanitizeForLog()` utility function when passing external, user-supplied, or potentially tampered strings to `LOG.warn`, `LOG.error`, or `LOG.info`.
+
+## 2024-05-24 - HTML Injection in Swing Table Renderers
+**Vulnerability:** A `DefaultTableCellRenderer` in `StickyProjectConfigurable` processed user-provided paths and descriptions without disabling HTML interpretation, leading to potential Cross-Site Scripting (XSS) / HTML Injection if malicious input like `<html>...` was used.
+**Learning:** Swing components (like `JLabel` and subclasses like `DefaultTableCellRenderer`) default to parsing strings starting with `<html>` as HTML. This can be exploited to spoof UI elements or perform injection attacks when displaying unvalidated user input or external paths.
+**Prevention:** Explicitly disable HTML rendering on Swing components displaying untrusted data by calling `(component as? JComponent)?.putClientProperty("html.disable", true)`.

--- a/src/main/kotlin/com/github/erjotek/stickyprojectfolder/settings/StickyProjectConfigurable.kt
+++ b/src/main/kotlin/com/github/erjotek/stickyprojectfolder/settings/StickyProjectConfigurable.kt
@@ -187,6 +187,10 @@ class StickyProjectConfigurable(
                 table: javax.swing.JTable, value: Any?, isSelected: Boolean, hasFocus: Boolean, row: Int, column: Int
             ): Component {
                 val comp = super.getTableCellRendererComponent(table, value, isSelected, hasFocus, row, column)
+
+                // Prevent HTML injection from malicious directory names or descriptions
+                (comp as? javax.swing.JComponent)?.putClientProperty("html.disable", true)
+
                 if (!isSelected) {
                     val item = pinnedTableModel?.items?.getOrNull(row)
                     if (item != null) {


### PR DESCRIPTION
🚨 **Severity**: HIGH
💡 **Vulnerability**: HTML Injection / XSS in Swing `DefaultTableCellRenderer`
🎯 **Impact**: A malicious folder name or description starting with `<html>` could be interpreted as HTML by the `StickyProjectConfigurable` settings table. This could lead to UI spoofing, layout distortion, or execution of unintended rendering logic (HTML Injection) when displaying untrusted project paths or user-provided folder descriptions.
🔧 **Fix**: Explicitly disabled HTML rendering for the table cell renderer component by setting the `html.disable` client property to `true` (`(comp as? javax.swing.JComponent)?.putClientProperty("html.disable", true)`).
✅ **Verification**: 
1. `DefaultTableCellRenderer` in `StickyProjectConfigurable.kt` was modified.
2. The project compiles successfully (`./gradlew compileKotlin -x test`).
3. The full test suite passes without regressions (`./gradlew test --no-daemon`).
4. A CRITICAL security learning entry was added to `.jules/sentinel.md` documenting this Swing-specific vulnerability pattern.

---
*PR created automatically by Jules for task [8014516409730540763](https://jules.google.com/task/8014516409730540763) started by @erjotek*