### PR TITLE
🛡️ Sentinel: [HIGH] Fix Log Forging / Log Injection Vulnerability in PinnedFooterComponent

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** Several logs (`StickyHeaderComponent.kt` tracking mimeTypes, `PinnedFoldersSettings.kt` and `PathValidator.kt` tracking file paths) logged external or user inputs directly via String template injection without sanitizing CRLF `\n` and `\r` characters.
 **Learning:** Even internal settings, file paths, and MIME types coming from system clipboards can be tampered with by an attacker to forge log entries or obscure traces.
 **Prevention:** Always use the `PathValidator.sanitizeForLog()` utility function when passing external, user-supplied, or potentially tampered strings to `LOG.warn`, `LOG.error`, or `LOG.info`.
+## 2026-03-24 - Fix Log Forging / Log Injection Vulnerability in PinnedFooterComponent
+**Vulnerability:** `PinnedFooterComponent.kt` logged external file paths directly via String template injection (`LOG.warn("Failed to get file color for ${item.path}", e)`) without sanitizing CRLF `\n` and `\r` characters.
+**Learning:** Even internal settings and file paths can be tampered with by an attacker to forge log entries or obscure traces.
+**Prevention:** Always use the `PathValidator.sanitizeForLog()` utility function when passing external, user-supplied, or potentially tampered strings to `LOG.warn`, `LOG.error`, or `LOG.info`.

--- a/src/main/kotlin/com/github/erjotek/stickyprojectfolder/ui/PinnedFooterComponent.kt
+++ b/src/main/kotlin/com/github/erjotek/stickyprojectfolder/ui/PinnedFooterComponent.kt
@@ -156,7 +156,7 @@ class PinnedFooterComponent(
                         colorManager.getFileColor(virtualFile)
                     } else null
                 } catch (e: Exception) {
-                    LOG.warn("Failed to get file color for ${item.path}", e)
+                    LOG.warn("Failed to get file color for ${com.github.erjotek.stickyprojectfolder.util.PathValidator.sanitizeForLog(item.path)}", e)
                     null
                 }
             }


### PR DESCRIPTION
🚨 **Severity**: MEDIUM/HIGH
💡 **Vulnerability**: `PinnedFooterComponent.kt` logs external user-provided data (`item.path`) directly without sanitization, leaving the application vulnerable to Log Forging or Log Injection via `\n` or `\r` characters.
🎯 **Impact**: Attackers could forge log entries or obscure traces by manipulating paths with newline characters.
🔧 **Fix**: Enveloped `item.path` in `com.github.erjotek.stickyprojectfolder.util.PathValidator.sanitizeForLog(item.path)` when it's passed to `LOG.warn`, ensuring proper sanitization. Added a corresponding entry in `.jules/sentinel.md`.
✅ **Verification**: Run `./gradlew test --no-daemon` to confirm the test suite continues to pass.

---
*PR created automatically by Jules for task [12934797704599290613](https://jules.google.com/task/12934797704599290613) started by @erjotek*