### PR TITLE
🛡️ Sentinel: [HIGH] Fix HTML Injection in Pinned Folders Table

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Several logs (`StickyHeaderComponent.kt` tracking mimeTypes, `PinnedFoldersSettings.kt` and `PathValidator.kt` tracking file paths) logged external or user inputs directly via String template injection without sanitizing CRLF `\n` and `\r` characters.
 **Learning:** Even internal settings, file paths, and MIME types coming from system clipboards can be tampered with by an attacker to forge log entries or obscure traces.
 **Prevention:** Always use the `PathValidator.sanitizeForLog()` utility function when passing external, user-supplied, or potentially tampered strings to `LOG.warn`, `LOG.error`, or `LOG.info`.
+
+## 2024-05-31 - Fix HTML Injection via Swing Cell Renderers
+**Vulnerability:** User-provided inputs (like file paths or descriptions) displayed in Swing components (like `DefaultTableCellRenderer` for `JTable`) were not sanitizing HTML. Swing components like `JLabel` interpret strings starting with `<html>` as HTML by default, leading to potential HTML injection/XSS.
+**Learning:** Default cell renderers and JLabels in Swing can execute embedded HTML if not explicitly disabled.
+**Prevention:** Always disable HTML rendering by calling `(component as? javax.swing.JComponent)?.putClientProperty("html.disable", true)` when displaying external or unvalidated strings in custom Swing renderers.

--- a/src/main/kotlin/com/github/erjotek/stickyprojectfolder/settings/StickyProjectConfigurable.kt
+++ b/src/main/kotlin/com/github/erjotek/stickyprojectfolder/settings/StickyProjectConfigurable.kt
@@ -187,6 +187,7 @@ class StickyProjectConfigurable(
                 table: javax.swing.JTable, value: Any?, isSelected: Boolean, hasFocus: Boolean, row: Int, column: Int
             ): Component {
                 val comp = super.getTableCellRendererComponent(table, value, isSelected, hasFocus, row, column)
+                (comp as? javax.swing.JComponent)?.putClientProperty("html.disable", true)
                 if (!isSelected) {
                     val item = pinnedTableModel?.items?.getOrNull(row)
                     if (item != null) {


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The Pinned Folders settings table uses a `DefaultTableCellRenderer` which naturally renders Strings starting with `<html>` as interpreted HTML. This means user-provided directory names or descriptions could execute embedded HTML, leading to potential XSS/HTML Injection inside the IDE settings pane.
🎯 **Impact:** An attacker or malicious repository structure could trick a user into viewing the Pinned Folders pane, executing unauthorized HTML code.
🔧 **Fix:** Explicitly added `.putClientProperty("html.disable", true)` to the `JComponent` rendered by `DefaultTableCellRenderer`.
✅ **Verification:** Verified via test suite run (`./gradlew test --no-daemon`) and code compilation. Reviewed logs to ensure no rendering exceptions are thrown. Added a Sentinel Log entry.

---
*PR created automatically by Jules for task [14545137382713733797](https://jules.google.com/task/14545137382713733797) started by @erjotek*