### PR TITLE
🛡️ Sentinel: [HIGH] Fix partial path matching vulnerabilities

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** Several logs (`StickyHeaderComponent.kt` tracking mimeTypes, `PinnedFoldersSettings.kt` and `PathValidator.kt` tracking file paths) logged external or user inputs directly via String template injection without sanitizing CRLF `\n` and `\r` characters.
 **Learning:** Even internal settings, file paths, and MIME types coming from system clipboards can be tampered with by an attacker to forge log entries or obscure traces.
 **Prevention:** Always use the `PathValidator.sanitizeForLog()` utility function when passing external, user-supplied, or potentially tampered strings to `LOG.warn`, `LOG.error`, or `LOG.info`.
+## 2026-03-26 - Fix Partial Path Matching Vulnerabilities
+**Vulnerability:** Partial path matching vulnerabilities existed in AutoCollapseManager, PinnedFolderActions, and StickyProjectConfigurable where .startsWith() was used to check if a file path was within the project's base path. For example, /project-abc/malicious would incorrectly match /project base path.
+**Learning:** Using .startsWith() for path validation is inherently insecure as it performs a string prefix match rather than a logical directory match.
+**Prevention:** Always use secure path validation methods like PathValidator.getValidatedRelativePath() that leverage java.nio.file.Path normalization and logical path containment checks.

--- a/src/main/kotlin/com/github/erjotek/stickyprojectfolder/actions/PinnedFolderActions.kt
+++ b/src/main/kotlin/com/github/erjotek/stickyprojectfolder/actions/PinnedFolderActions.kt
@@ -15,8 +15,7 @@ private fun getPinnedRelativePath(event: AnActionEvent): String? {
     val virtualFile = event.getData(CommonDataKeys.VIRTUAL_FILE) ?: return null
     if (!virtualFile.isDirectory) return null
     val filePath = virtualFile.path
-    if (!filePath.startsWith(basePath)) return null
-    var relative = filePath.removePrefix(basePath).removePrefix("/")
+    var relative = PathValidator.getValidatedRelativePath(basePath, filePath) ?: return null
     if (relative.isNotEmpty() && !relative.endsWith("/")) relative += "/"
     return relative.takeIf { it.isNotEmpty() }
 }

--- a/src/main/kotlin/com/github/erjotek/stickyprojectfolder/settings/StickyProjectConfigurable.kt
+++ b/src/main/kotlin/com/github/erjotek/stickyprojectfolder/settings/StickyProjectConfigurable.kt
@@ -251,8 +251,9 @@ private fun addPinnedFolder() {
             val basePath = project.basePath ?: return@chooseFile
             val selectedPath = selectedFile.path
 
-            if (selectedPath.startsWith(basePath)) {
-                var relativePath = selectedPath.removePrefix(basePath).removePrefix("/")
+            val validatedRelative = PathValidator.getValidatedRelativePath(basePath, selectedPath)
+            if (validatedRelative != null) {
+                var relativePath = validatedRelative
                 if (relativePath.isNotEmpty() && !relativePath.endsWith("/")) {
                     relativePath += "/"
                 }

--- a/src/main/kotlin/com/github/erjotek/stickyprojectfolder/ui/AutoCollapseManager.kt
+++ b/src/main/kotlin/com/github/erjotek/stickyprojectfolder/ui/AutoCollapseManager.kt
@@ -208,11 +208,7 @@ class AutoCollapseManager(
             return excludedRoots
                 .mapNotNull { root ->
                     val path = root.path
-                    if (!path.startsWith(basePath)) {
-                        null
-                    } else {
-                        path.removePrefix(basePath).removePrefix("/")
-                    }
+                    PathValidator.getValidatedRelativePath(basePath, path)
                 }
                 .filter { it.isNotBlank() }
         }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Partial path matching using `.startsWith()` (e.g., `if (filePath.startsWith(basePath))`) existed in `PinnedFolderActions.kt`, `StickyProjectConfigurable.kt`, and `AutoCollapseManager.kt`. This allows directory spoofing where `/project-abc/malicious` matches `/project`.
🎯 Impact: Attackers or malformed paths could bypass path containment validations by leveraging a prefix match instead of a valid directory containment match, potentially manipulating unintended paths or settings.
🔧 Fix: Replaced all simple string `.startsWith()` path checks with the secure `PathValidator.getValidatedRelativePath()` which correctly resolves and normalizes paths using `java.nio.file.Path` to verify logical directory containment.
✅ Verification: `gradlew test --no-daemon` ran successfully and confirmed no regressions.

---
*PR created automatically by Jules for task [15434743742883527217](https://jules.google.com/task/15434743742883527217) started by @erjotek*