### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in JTable Renderer

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** Several logs (`StickyHeaderComponent.kt` tracking mimeTypes, `PinnedFoldersSettings.kt` and `PathValidator.kt` tracking file paths) logged external or user inputs directly via String template injection without sanitizing CRLF `\n` and `\r` characters.
 **Learning:** Even internal settings, file paths, and MIME types coming from system clipboards can be tampered with by an attacker to forge log entries or obscure traces.
 **Prevention:** Always use the `PathValidator.sanitizeForLog()` utility function when passing external, user-supplied, or potentially tampered strings to `LOG.warn`, `LOG.error`, or `LOG.info`.
+## 2024-05-30 - Fix UI XSS Vulnerability in JTable Renderer
+**Vulnerability:** The `DefaultTableCellRenderer` used for the `pinnedTable` in `StickyProjectConfigurable.kt` did not disable HTML rendering, making it vulnerable to UI-based Cross-Site Scripting (XSS) if user input or external data starting with `<html>` was rendered.
+**Learning:** Swing components like `JLabel` (and subclasses like `DefaultTableCellRenderer`) interpret strings starting with `<html>` as HTML by default. This can lead to potential HTML injection/XSS or arbitrary local file reads.
+**Prevention:** When displaying user-provided or unvalidated strings (e.g., file/directory paths) in Swing components, explicitly disable HTML rendering by calling `.putClientProperty("html.disable", true)`. Use a safe cast `(comp as? javax.swing.JComponent)?.putClientProperty("html.disable", true)` to prevent `ClassCastException`.

--- a/src/main/kotlin/com/github/erjotek/stickyprojectfolder/settings/StickyProjectConfigurable.kt
+++ b/src/main/kotlin/com/github/erjotek/stickyprojectfolder/settings/StickyProjectConfigurable.kt
@@ -187,6 +187,8 @@ class StickyProjectConfigurable(
                 table: javax.swing.JTable, value: Any?, isSelected: Boolean, hasFocus: Boolean, row: Int, column: Int
             ): Component {
                 val comp = super.getTableCellRendererComponent(table, value, isSelected, hasFocus, row, column)
+                (comp as? javax.swing.JComponent)?.putClientProperty("html.disable", true)
+
                 if (!isSelected) {
                     val item = pinnedTableModel?.items?.getOrNull(row)
                     if (item != null) {


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `DefaultTableCellRenderer` used for the `pinnedTable` in `StickyProjectConfigurable.kt` did not explicitly disable HTML rendering. Because Swing `JLabel` (which `DefaultTableCellRenderer` relies on) automatically renders text starting with `<html>`, this created a vulnerability for UI-based Cross-Site Scripting (XSS).
🎯 Impact: If user input or external data (like crafted folder descriptions or forged paths) starting with `<html>` was loaded into the table, it could be executed/rendered by the Swing framework, potentially leading to UI spoofing or execution of arbitrary code within the IDE context.
🔧 Fix: Modified the `getTableCellRendererComponent` to use a safe cast `(comp as? javax.swing.JComponent)?.putClientProperty("html.disable", true)` to disable HTML rendering on the component before it is returned.
✅ Verification: Ran `./gradlew test --no-daemon` and confirmed all tests pass. Also verified successful plugin compilation.

---
*PR created automatically by Jules for task [11515210861991900463](https://jules.google.com/task/11515210861991900463) started by @erjotek*