### PR TITLE
perf+cleanup: combine PR #91, #93, #95

### DIFF
--- a/src/main/kotlin/com/github/erjotek/stickyprojectfolder/pinned/PinnedFoldersManager.kt
+++ b/src/main/kotlin/com/github/erjotek/stickyprojectfolder/pinned/PinnedFoldersManager.kt
@@ -2,7 +2,6 @@ package com.github.erjotek.stickyprojectfolder.pinned
 
 import com.github.erjotek.stickyprojectfolder.ui.PinnedFooterComponent
 import com.intellij.ide.projectView.ProjectView
-import com.intellij.ide.projectView.impl.AbstractProjectViewPane
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.util.Computable
@@ -13,11 +12,9 @@ import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.wm.ToolWindowId
 import com.intellij.openapi.wm.ToolWindowManager
 import com.intellij.openapi.wm.ex.ToolWindowManagerListener
+import com.github.erjotek.stickyprojectfolder.util.TreeContextResolver
 import com.intellij.psi.PsiManager
 import com.intellij.util.ui.tree.TreeUtil
-import java.awt.Component
-import java.awt.Container
-import java.awt.KeyboardFocusManager
 import java.awt.event.AdjustmentListener
 import java.awt.event.ComponentAdapter
 import java.awt.event.ComponentEvent
@@ -72,7 +69,7 @@ class PinnedFoldersManager(private val project: Project) : Disposable {
         val projectView = ProjectView.getInstance(project)
         val pane = projectView.currentProjectViewPane
 
-        val context = resolveTreeContext(pane)
+        val context = TreeContextResolver.resolve(project, pane)
         if (context == null) return
 
         val currentTree = context.tree
@@ -112,55 +109,6 @@ class PinnedFoldersManager(private val project: Project) : Disposable {
         installListeners(sp)
     }
     
-    // ... Copy-paste resolveTreeContext helpers from StickyScrollManager ...
-    // To avoid duplication I should have shared them, but for speed I'll replicate relevant parts roughly.
-    private data class TreeContext(val tree: JTree, val scrollPane: JScrollPane)
-    
-    private fun resolveTreeContext(pane: AbstractProjectViewPane?): TreeContext? {
-        fun toContext(tree: JTree): TreeContext? {
-            val sp = SwingUtilities.getAncestorOfClass(JScrollPane::class.java, tree) as? JScrollPane ?: return null
-            return TreeContext(tree, sp)
-        }
-
-        resolveFocusedProjectViewTree()?.let { focusedTree ->
-            toContext(focusedTree)?.let { return it }
-        }
-
-        val treeFromPane = pane?.tree
-        if (treeFromPane != null && treeFromPane.isShowing) {
-            toContext(treeFromPane)?.let { return it }
-        }
-
-        val toolWindow = ToolWindowManager.getInstance(project).getToolWindow(ToolWindowId.PROJECT_VIEW) ?: return null
-        val treeFromToolWindow = findTree(toolWindow.component) ?: return null
-        return toContext(treeFromToolWindow)
-    }
-
-    private fun resolveFocusedProjectViewTree(): JTree? {
-        val toolWindow = ToolWindowManager.getInstance(project).getToolWindow(ToolWindowId.PROJECT_VIEW) ?: return null
-        val toolWindowComponent = toolWindow.component
-
-        val focusOwner = KeyboardFocusManager.getCurrentKeyboardFocusManager().focusOwner ?: return null
-        if (!SwingUtilities.isDescendingFrom(focusOwner, toolWindowComponent)) return null
-
-        return when (focusOwner) {
-            is JTree -> focusOwner
-            else -> SwingUtilities.getAncestorOfClass(JTree::class.java, focusOwner) as? JTree
-        }
-    }
-
-    private fun findTree(component: Component?): JTree? {
-        if (component == null) return null
-        if (component is JTree && component.isShowing) return component
-        if (component is Container) {
-            for (child in component.components) {
-                val tree = findTree(child)
-                if (tree != null) return tree
-            }
-        }
-        return null
-    }
-
     private fun installListeners(sp: JScrollPane) {
         if (adjustmentListener == null) {
             val updateAction = Runnable { 

--- a/src/main/kotlin/com/github/erjotek/stickyprojectfolder/ui/PinnedFooterComponent.kt
+++ b/src/main/kotlin/com/github/erjotek/stickyprojectfolder/ui/PinnedFooterComponent.kt
@@ -326,9 +326,11 @@ class PinnedFooterComponent(
             try {
                 val data = transferable.getTransferData(DataFlavor.javaFileListFlavor)
                 if (data is List<*>) {
+                    val lfs = LocalFileSystem.getInstance()
+                    val psiManager = PsiManager.getInstance(project)
                     for (file in data.filterIsInstance<java.io.File>()) {
-                        val vf = LocalFileSystem.getInstance().findFileByIoFile(file) ?: continue
-                        val psi = if (vf.isDirectory) PsiManager.getInstance(project).findDirectory(vf) else PsiManager.getInstance(project).findFile(vf)
+                        val vf = lfs.findFileByIoFile(file) ?: continue
+                        val psi = if (vf.isDirectory) psiManager.findDirectory(vf) else psiManager.findFile(vf)
                         if (psi != null) elements.add(psi)
                     }
                 }

--- a/src/main/kotlin/com/github/erjotek/stickyprojectfolder/ui/StickyHeaderComponent.kt
+++ b/src/main/kotlin/com/github/erjotek/stickyprojectfolder/ui/StickyHeaderComponent.kt
@@ -1,7 +1,6 @@
 package com.github.erjotek.stickyprojectfolder.ui
 
 import com.github.erjotek.stickyprojectfolder.MyBundle
-import com.intellij.ide.projectView.ProjectViewNode
 import com.intellij.ide.util.treeView.AbstractTreeNode
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.ApplicationManager
@@ -11,8 +10,6 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiDirectory
-import com.intellij.psi.PsiDirectoryContainer
-import com.intellij.psi.PsiFileSystemItem
 import com.intellij.openapi.ui.Messages
 import com.intellij.refactoring.copy.CopyHandler
 import com.intellij.ui.ColorUtil
@@ -207,7 +204,7 @@ class StickyHeaderComponent(
 
         val vf = extractVirtualFileFromNode(node)
         if (vf != null) {
-            val element = resolvePsiElement(vf)
+            val element = resolvePsiElement(vf, com.intellij.psi.PsiManager.getInstance(project))
             if (element is PsiDirectory) return element
         }
 
@@ -303,6 +300,7 @@ class StickyHeaderComponent(
 
     private fun extractPsiElementsFromTransferable(transferable: Transferable): Array<PsiElement> {
         val elements = mutableListOf<PsiElement>()
+        val psiManager = com.intellij.psi.PsiManager.getInstance(project)
 
         if (transferable.isDataFlavorSupported(DataFlavor.javaFileListFlavor)) {
             var data: Any? = null
@@ -315,13 +313,13 @@ class StickyHeaderComponent(
                     LOG.error("Failed to get transfer data for javaFileListFlavor", e)
                 }
             }
-            if (data is java.util.List<*>) {
-                val files = data.filterIsInstance<java.io.File>()
-                for (file in files) {
-                    val vf = com.intellij.openapi.vfs.LocalFileSystem.getInstance().findFileByIoFile(file) ?: continue
-                    val psi = resolvePsiElement(vf)
-                    if (psi != null) elements.add(psi)
-                }
+            if (data is List<*>) {
+                val lfs = com.intellij.openapi.vfs.LocalFileSystem.getInstance()
+                data.asSequence()
+                    .filterIsInstance<java.io.File>()
+                    .mapNotNull { lfs.findFileByIoFile(it) }
+                    .mapNotNull { resolvePsiElement(it, psiManager) }
+                    .forEach { elements.add(it) }
             }
         }
 
@@ -344,18 +342,18 @@ class StickyHeaderComponent(
 
             when (data) {
                 is Array<*> -> {
-                    data.filterIsInstance<VirtualFile>().forEach { vf ->
-                        val psi = resolvePsiElement(vf)
-                        if (psi != null) elements.add(psi)
-                    }
+                    data.asSequence()
+                        .filterIsInstance<VirtualFile>()
+                        .mapNotNull { resolvePsiElement(it, psiManager) }
+                        .forEach { elements.add(it) }
 
                     data.filterIsInstance<PsiElement>().forEach { elements.add(it) }
                 }
                 is Collection<*> -> {
-                    data.filterIsInstance<VirtualFile>().forEach { vf ->
-                        val psi = resolvePsiElement(vf)
-                        if (psi != null) elements.add(psi)
-                    }
+                    data.asSequence()
+                        .filterIsInstance<VirtualFile>()
+                        .mapNotNull { resolvePsiElement(it, psiManager) }
+                        .forEach { elements.add(it) }
 
                     data.filterIsInstance<PsiElement>().forEach { elements.add(it) }
                 }
@@ -365,11 +363,11 @@ class StickyHeaderComponent(
         return elements.distinct().toTypedArray()
     }
 
-    private fun resolvePsiElement(vf: VirtualFile): PsiElement? {
+    private fun resolvePsiElement(vf: VirtualFile, psiManager: com.intellij.psi.PsiManager): PsiElement? {
         return if (vf.isDirectory) {
-            com.intellij.psi.PsiManager.getInstance(project).findDirectory(vf)
+            psiManager.findDirectory(vf)
         } else {
-            com.intellij.psi.PsiManager.getInstance(project).findFile(vf)
+            psiManager.findFile(vf)
         }
     }
 
@@ -467,10 +465,12 @@ class StickyHeaderComponent(
     private fun moveFilesToDirectory(files: List<java.io.File>, targetDir: PsiDirectory) {
         LOG.info("moveFilesToDirectory called: ${files.size} files")
 
+        val psiManager = com.intellij.psi.PsiManager.getInstance(project)
+        val lfs = com.intellij.openapi.vfs.LocalFileSystem.getInstance()
         val psiElements = files.mapNotNull { file ->
             ApplicationManager.getApplication().runReadAction(Computable {
-                val vf = com.intellij.openapi.vfs.LocalFileSystem.getInstance().findFileByIoFile(file)
-                if (vf != null) resolvePsiElement(vf) else null
+                val vf = lfs.findFileByIoFile(file)
+                if (vf != null) resolvePsiElement(vf, psiManager) else null
             })
         }.toTypedArray()
 

--- a/src/main/kotlin/com/github/erjotek/stickyprojectfolder/ui/StickyScrollManager.kt
+++ b/src/main/kotlin/com/github/erjotek/stickyprojectfolder/ui/StickyScrollManager.kt
@@ -1,7 +1,6 @@
 package com.github.erjotek.stickyprojectfolder.ui
 
 import com.intellij.ide.projectView.ProjectView
-import com.intellij.ide.projectView.impl.AbstractProjectViewPane
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.diagnostic.Logger
@@ -10,6 +9,7 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.wm.ToolWindowId
 import com.intellij.openapi.wm.ToolWindowManager
 import com.intellij.openapi.wm.ex.ToolWindowManagerListener
+import com.github.erjotek.stickyprojectfolder.util.TreeContextResolver
 import com.intellij.ui.content.ContentManagerEvent
 import com.intellij.ui.content.ContentManagerListener
 import java.awt.*
@@ -96,7 +96,7 @@ class StickyScrollManager(private val project: Project) : Disposable {
             toolWindow.contentManager.addContentManagerListener(listener)
         }
 
-        val context = resolveTreeContext(pane)
+        val context = TreeContextResolver.resolve(project, pane)
         if (context == null) {
             if (this.tree != null) {
                 detach()
@@ -159,53 +159,6 @@ class StickyScrollManager(private val project: Project) : Disposable {
             com.intellij.openapi.util.Disposer.register(this, autoCollapseManager!!)
             autoCollapseManager?.install()
         }
-    }
-
-    private data class TreeContext(val tree: JTree, val scrollPane: JScrollPane)
-
-    private fun resolveTreeContext(pane: AbstractProjectViewPane?): TreeContext? {
-        fun toContext(tree: JTree): TreeContext? {
-            val sp = SwingUtilities.getAncestorOfClass(JScrollPane::class.java, tree) as? JScrollPane ?: return null
-            return TreeContext(tree, sp)
-        }
-
-        resolveFocusedProjectViewTree()?.let { focusedTree ->
-            toContext(focusedTree)?.let { return it }
-        }
-
-        val treeFromPane = pane?.tree
-        if (treeFromPane != null && treeFromPane.isShowing) {
-            toContext(treeFromPane)?.let { return it }
-        }
-
-        val toolWindow = ToolWindowManager.getInstance(project).getToolWindow(ToolWindowId.PROJECT_VIEW) ?: return null
-        val treeFromToolWindow = findTree(toolWindow.component) ?: return null
-        return toContext(treeFromToolWindow)
-    }
-
-    private fun resolveFocusedProjectViewTree(): JTree? {
-        val toolWindow = ToolWindowManager.getInstance(project).getToolWindow(ToolWindowId.PROJECT_VIEW) ?: return null
-        val toolWindowComponent = toolWindow.component
-
-        val focusOwner = KeyboardFocusManager.getCurrentKeyboardFocusManager().focusOwner ?: return null
-        if (!SwingUtilities.isDescendingFrom(focusOwner, toolWindowComponent)) return null
-
-        return when (focusOwner) {
-            is JTree -> focusOwner
-            else -> SwingUtilities.getAncestorOfClass(JTree::class.java, focusOwner) as? JTree
-        }
-    }
-
-    private fun findTree(component: Component?): JTree? {
-        if (component == null) return null
-        if (component is JTree && component.isShowing) return component
-        if (component is Container) {
-            for (child in component.components) {
-                val tree = findTree(child)
-                if (tree != null) return tree
-            }
-        }
-        return null
     }
 
     private fun installListeners(sp: JScrollPane, currentTree: JTree) {

--- a/src/main/kotlin/com/github/erjotek/stickyprojectfolder/util/TreeContextResolver.kt
+++ b/src/main/kotlin/com/github/erjotek/stickyprojectfolder/util/TreeContextResolver.kt
@@ -1,0 +1,62 @@
+package com.github.erjotek.stickyprojectfolder.util
+
+import com.intellij.ide.projectView.impl.AbstractProjectViewPane
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.wm.ToolWindowId
+import com.intellij.openapi.wm.ToolWindowManager
+import java.awt.Component
+import java.awt.Container
+import java.awt.KeyboardFocusManager
+import javax.swing.JScrollPane
+import javax.swing.JTree
+import javax.swing.SwingUtilities
+
+data class TreeContext(val tree: JTree, val scrollPane: JScrollPane)
+
+object TreeContextResolver {
+
+    fun resolve(project: Project, pane: AbstractProjectViewPane?): TreeContext? {
+        fun toContext(tree: JTree): TreeContext? {
+            val sp = SwingUtilities.getAncestorOfClass(JScrollPane::class.java, tree) as? JScrollPane ?: return null
+            return TreeContext(tree, sp)
+        }
+
+        resolveFocusedProjectViewTree(project)?.let { focusedTree ->
+            toContext(focusedTree)?.let { return it }
+        }
+
+        val treeFromPane = pane?.tree
+        if (treeFromPane != null && treeFromPane.isShowing) {
+            toContext(treeFromPane)?.let { return it }
+        }
+
+        val toolWindow = ToolWindowManager.getInstance(project).getToolWindow(ToolWindowId.PROJECT_VIEW) ?: return null
+        val treeFromToolWindow = findTree(toolWindow.component) ?: return null
+        return toContext(treeFromToolWindow)
+    }
+
+    private fun resolveFocusedProjectViewTree(project: Project): JTree? {
+        val toolWindow = ToolWindowManager.getInstance(project).getToolWindow(ToolWindowId.PROJECT_VIEW) ?: return null
+        val toolWindowComponent = toolWindow.component
+
+        val focusOwner = KeyboardFocusManager.getCurrentKeyboardFocusManager().focusOwner ?: return null
+        if (!SwingUtilities.isDescendingFrom(focusOwner, toolWindowComponent)) return null
+
+        return when (focusOwner) {
+            is JTree -> focusOwner
+            else -> SwingUtilities.getAncestorOfClass(JTree::class.java, focusOwner) as? JTree
+        }
+    }
+
+    private fun findTree(component: Component?): JTree? {
+        if (component == null) return null
+        if (component is JTree && component.isShowing) return component
+        if (component is Container) {
+            for (child in component.components) {
+                val tree = findTree(child)
+                if (tree != null) return tree
+            }
+        }
+        return null
+    }
+}


### PR DESCRIPTION
Combines three independent optimization/cleanup PRs into one branch, dropping the unrelated isPluginEnabled rewrites that #93 and #95 each smuggled in (out of scope, mutually conflicting, semantics-changing).

#91 StickyHeaderComponent: hoist PsiManager/LocalFileSystem service
    lookups out of the per-file loops; thread PsiManager into
    resolvePsiElement; drop unused imports. Preserves element ordering.

#93 Extract duplicated tree-resolution logic (findTree /
    resolveFocusedProjectViewTree / resolveTreeContext + TreeContext)
    from StickyScrollManager and PinnedFoldersManager into a shared
    util/TreeContextResolver. Removed now-orphaned imports.
    (isPluginEnabled langMap rewrite from the original PR dropped.)

#95 PinnedFooterComponent: hoist LocalFileSystem/PsiManager lookups
    out of the drag-drop loop. (isPluginEnabled change dropped.)

StickyProjectConfigurable.kt intentionally untouched. compileKotlin + test both green.